### PR TITLE
Alternative hosts configuration

### DIFF
--- a/CHANGELOG-TRELLIS-DATABASE-UPLOADS-MIGRATION.md
+++ b/CHANGELOG-TRELLIS-DATABASE-UPLOADS-MIGRATION.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Improve hosts configuration and other small fixes and typos ([#17](https://github.com/valentinocossar/trellis-database-uploads-migration/pull/17))
 * Improve development host configuration and tested up to Ansible 2.6.1 ([#15](https://github.com/valentinocossar/trellis-database-uploads-migration/issues/15))
 * Update LICENSE.md
 * Improve README.md ([#9](https://github.com/valentinocossar/trellis-database-uploads-migration/issues/9))

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # 🎩 trellis-database-uploads-migration
+
 Ansible playbook for Trellis that manages database and uploads migration. Inspired by [hamedb89/trellis-db-push-and-pull](https://github.com/hamedb89/trellis-db-push-and-pull).
 
 ## ⚙️ Installation
+
 1. [Download latest release](https://github.com/valentinocossar/trellis-database-uploads-migration/releases/latest)
 2. Copy `CHANGELOG-TRELLIS-DATABASE-UPLOADS-MIGRATION.md` file into Trellis root folder (so you can always know the version of the tool you are using)
 3. Copy all `*.yml` files into Trellis root folder
@@ -10,6 +12,7 @@ Ansible playbook for Trellis that manages database and uploads migration. Inspir
 6. Set alias for host files as mentioned below in the hosts configuration section
 
 ### ‼️ Important
+
 * Tested up to Ansible 2.6.1
 * This tool doesn't work with Ansible 2.4.1.0 due to a bug (see [#9](https://github.com/valentinocossar/trellis-database-uploads-migration/issues/9))
 * The development vagrant VM must be powered on every time you run a command, this because the tool checks if the site folder exists and its name is the same of the `local_path` parameter in `wordpress_sites.yml`
@@ -20,42 +23,49 @@ Ansible playbook for Trellis that manages database and uploads migration. Inspir
 * This tool has only been tested with macOS and Ubuntu 18.04 LTS, any help with other operating systems would be appreciated
 
 ## 🏄 Usage
+
 * Run `./bin/uploads.sh <environment> <site name> <mode>`
 * Run `./bin/database.sh <environment> <site name> <mode>`
 
 ### 📌 Tips
+
 * Available `<mode>` options for uploads task: `push`, `pull`
 * Available `<mode>` options for database task: `push`, `pull`, `backup`
 * The `push` is for sending to the selected environment and the `pull` for receiving from it
 * The `backup` is for backup the database of the selected environment
 
 ## 🛠 Hosts configuration
+
 ### Development
-```
+
+```ini
 [development]
 development_host ansible_host=192.168.50.5 ansible_connection=ssh ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_ssh_extra_args="-o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ForwardAgent=yes"
 
 [web]
-development_host
+development_host ansible_host=192.168.50.5 ansible_connection=ssh ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_ssh_extra_args="-o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ForwardAgent=yes"
 ```
 
 ### Staging
-```
+
+```ini
 [staging]
 staging_host ansible_host=your_server_hostname
 
 [web]
-staging_host
+staging_host ansible_host=your_server_hostname
 ```
 
 ### Production
-```
+
+```ini
 [production]
 production_host ansible_host=your_server_hostname
 
 [web]
-production_host
+production_host ansible_host=your_server_hostname
 ```
+
 ## 🤝 Contributing
 
 1. [Fork it](https://github.com/valentinocossar/trellis-database-uploads-migration/fork)

--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ Ansible playbook for Trellis that manage database and uploads migration. Inspire
 ## 🛠 Hosts configuration
 ### Development
 ```
-development_host ansible_host=192.168.50.5 ansible_connection=ssh ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_ssh_extra_args="-o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ForwardAgent=yes"
-
 [development]
+development_host ansible_host=192.168.50.5 ansible_connection=ssh ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_ssh_extra_args="-o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ForwardAgent=yes"
 development_host
 
 [web]
@@ -43,9 +42,8 @@ development_host
 
 ### Staging
 ```
-staging_host ansible_host=your_server_hostname
-
 [staging]
+staging_host ansible_host=your_server_hostname
 staging_host
 
 [web]
@@ -54,51 +52,13 @@ staging_host
 
 ### Production
 ```
-production_host ansible_host=your_server_hostname
-
 [production]
+production_host ansible_host=your_server_hostname
 production_host
 
 [web]
 production_host
 ```
-
-## 🛠 Alternative hosts configuration
-Some users have [reported receiving errors when using the above hosts configuration](https://github.com/valentinocossar/trellis-database-uploads-migration/issues/16). It is recommended to try this alternative configuration if you encounter an error similar to this:
-```
-The task includes an option with an undefined variable. The error was: 'dict
-object' has no attribute 'wordpress_sites'
-```
-### Development
-```
-[development]
-development_host ansible_host=192.168.50.5 ansible_connection=ssh ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_ssh_extra_args="-o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ForwardAgent=yes"
-192.168.50.5 ansible_connection=local
-
-[web]
-192.168.50.5 ansible_connection=local
-```
-
-### Staging
-```
-[staging]
-staging_host ansible_host=your_server_hostname
-your_server_hostname
-
-[web]
-your_server_hostname
-```
-
-### Production
-```
-[production]
-production_host ansible_host=your_server_hostname
-your_server_hostname
-
-[web]
-your_server_hostname
-```
-
 ## 🤝 Contributing
 
 1. [Fork it](https://github.com/valentinocossar/trellis-database-uploads-migration/fork)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ production_host
 ```
 
 ## 🛠 Alternative hosts configuration
-Some users have [reported errors with the above configuration](https://github.com/valentinocossar/trellis-database-uploads-migration/issues/16). It is recommended to try this alternative hosts configuration if you encounter an error like this:
+Some users have [reported receiving errors when using the above hosts configuration](https://github.com/valentinocossar/trellis-database-uploads-migration/issues/16). It is recommended to try this alternative configuration if you encounter an error similar to this:
 ```
 The task includes an option with an undefined variable. The error was: 'dict
 object' has no attribute 'wordpress_sites'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Ansible playbook for Trellis that manage database and uploads migration. Inspire
 * I recommend you to not perform `git` operations while running `./bin/database.sh` command, this because the tool uses the Bedrock folder as temp folder to store database dump before importing/exporting it and then delete it
 * To support url search and replace for Trellis 0.9.8 and lower, remove `.canonical` from variables `url_from` and `url_to` in the files `database-pull.yml` and `database-push.yml`
 * This tool hasn't been tested with a multisite configuration, any help with this implementation would be appreciated
-* This tool has only been tested with macOS, any help with other OS would be appreciated
+* This tool has only been tested with macOS and Ubuntu 18.04 LTS, any help with other operating systems would be appreciated
 
 ## 🏄 Usage
 * Run `./bin/uploads.sh <environment> <site name> <mode>`
@@ -26,8 +26,8 @@ Ansible playbook for Trellis that manage database and uploads migration. Inspire
 ### 📌 Tips
 * Available `<mode>` options for uploads task: `push`, `pull`
 * Available `<mode>` options for database task: `push`, `pull`, `backup`
-* The `push` is for sending to the selected environment and the `pull` for receiving from it.
-* The `backup` is for backup the database of the selected environment.
+* The `push` is for sending to the selected environment and the `pull` for receiving from it
+* The `backup` is for backup the database of the selected environment
 
 ## 🛠 Hosts configuration
 ### Development

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Ansible playbook for Trellis that manage database and uploads migration. Inspire
 ```
 [development]
 development_host ansible_host=192.168.50.5 ansible_connection=ssh ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_ssh_extra_args="-o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ForwardAgent=yes"
-development_host
 
 [web]
 development_host
@@ -44,7 +43,6 @@ development_host
 ```
 [staging]
 staging_host ansible_host=your_server_hostname
-staging_host
 
 [web]
 staging_host
@@ -54,7 +52,6 @@ staging_host
 ```
 [production]
 production_host ansible_host=your_server_hostname
-production_host
 
 [web]
 production_host

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 🎩 trellis-database-uploads-migration
-Ansible playbook for Trellis that manage database and uploads migration. Inspired by [hamedb89/trellis-db-push-and-pull](https://github.com/hamedb89/trellis-db-push-and-pull).
+Ansible playbook for Trellis that manages database and uploads migration. Inspired by [hamedb89/trellis-db-push-and-pull](https://github.com/hamedb89/trellis-db-push-and-pull).
 
 ## ⚙️ Installation
 1. [Download latest release](https://github.com/valentinocossar/trellis-database-uploads-migration/releases/latest)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,45 @@ Ansible playbook for Trellis that manage database and uploads migration. Inspire
 ## 🛠 Hosts configuration
 ### Development
 ```
+development_host ansible_host=192.168.50.5 ansible_connection=ssh ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_ssh_extra_args="-o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ForwardAgent=yes"
+
+[development]
+development_host
+
+[web]
+development_host
+```
+
+### Staging
+```
+staging_host ansible_host=your_server_hostname
+
+[staging]
+staging_host
+
+[web]
+staging_host
+```
+
+### Production
+```
+production_host ansible_host=your_server_hostname
+
+[production]
+production_host
+
+[web]
+production_host
+```
+
+## 🛠 Alternative hosts configuration
+Some users have [reported errors with the above configuration](https://github.com/valentinocossar/trellis-database-uploads-migration/issues/16). It is recommended to try this alternative hosts configuration if you encounter an error like this:
+```
+The task includes an option with an undefined variable. The error was: 'dict
+object' has no attribute 'wordpress_sites'
+```
+### Development
+```
 [development]
 development_host ansible_host=192.168.50.5 ansible_connection=ssh ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_ssh_extra_args="-o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ForwardAgent=yes"
 192.168.50.5 ansible_connection=local

--- a/README.md
+++ b/README.md
@@ -32,35 +32,32 @@ Ansible playbook for Trellis that manage database and uploads migration. Inspire
 ## 🛠 Hosts configuration
 ### Development
 ```
-development_host ansible_host=192.168.50.5 ansible_connection=ssh ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_ssh_extra_args="-o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ForwardAgent=yes"
-
 [development]
-development_host
+development_host ansible_host=192.168.50.5 ansible_connection=ssh ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_ssh_extra_args="-o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ForwardAgent=yes"
+192.168.50.5 ansible_connection=local
 
 [web]
-development_host
+192.168.50.5 ansible_connection=local
 ```
 
 ### Staging
 ```
-staging_host ansible_host=your_server_hostname
-
 [staging]
-staging_host
+staging_host ansible_host=your_server_hostname
+your_server_hostname
 
 [web]
-staging_host
+your_server_hostname
 ```
 
 ### Production
 ```
-production_host ansible_host=your_server_hostname
-
 [production]
-production_host
+production_host ansible_host=your_server_hostname
+your_server_hostname
 
 [web]
-production_host
+your_server_hostname
 ```
 
 ## 🤝 Contributing

--- a/database-backup.yml
+++ b/database-backup.yml
@@ -19,7 +19,7 @@
       path: "{{ project_root }}"
     register: result
 
-  - name: Abort if {{ site }} folder doesn't exists
+  - name: Abort if {{ site }} folder doesn't exist
     fail:
       msg: "ERROR: {{ site }} is not a valid site name ({{ site }} folder does not exist)."
     when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false
@@ -39,21 +39,20 @@
         chdir: "{{ project_web_dir }}"
       when: env is defined and env == "development"
 
-    - name: Export staging/production database
+    - name: Export {{ env }} database
       shell: wp db export - | gzip > {{ backup_file }}
       args:
         chdir: "{{ project_web_dir }}"
       when: env is defined and env != "development"
 
-    - name: Pull exported database from staging/production to development
+    - name: Pull exported database from {{ env }} to development
       fetch:
-        src: "{{project_web_dir}}/{{ backup_file }}"
+        src: "{{ project_web_dir }}/{{ backup_file }}"
         dest: "{{ local_bedrock_dir }}/database_backup/"
         flat: yes
       when: env is defined and env != "development"
 
-    - name: Delete exported database from staging/production
-      delegate_to: development_host
+    - name: Delete exported database from {{ env }}
       shell: rm -f {{ backup_file }}
       args:
         chdir: "{{ project_web_dir }}"

--- a/database-pull.yml
+++ b/database-pull.yml
@@ -27,7 +27,7 @@
       path: "{{ project_root }}"
     register: result
 
-  - name: Abort if {{ site }} folder doesn't exists
+  - name: Abort if {{ site }} folder doesn't exist
     fail:
       msg: "ERROR: {{ site }} is not a valid site name ({{ site }} folder does not exist)."
     when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false
@@ -47,7 +47,7 @@
 
     - name: Pull database dump from {{ env }} to development
       fetch:
-        src: "{{project_web_dir}}/{{ dump_file }}"
+        src: "{{ project_web_dir }}/{{ dump_file }}"
         dest: "{{ local_bedrock_dir }}/"
         flat: yes
 

--- a/database-push.yml
+++ b/database-push.yml
@@ -27,7 +27,7 @@
       path: "{{ project_root }}"
     register: result
 
-  - name: Abort if {{ site }} folder doesn't exists
+  - name: Abort if {{ site }} folder doesn't exist
     fail:
       msg: "ERROR: {{ site }} is not a valid site name ({{ site }} folder does not exist)."
     when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false

--- a/uploads.yml
+++ b/uploads.yml
@@ -19,7 +19,7 @@
       path: "{{ project_root }}"
     register: result
 
-  - name: Abort if {{ site }} folder doesn't exists
+  - name: Abort if {{ site }} folder doesn't exist
     fail:
       msg: "ERROR: {{ site }} is not a valid site name ({{ site }} folder does not exist)."
     when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false


### PR DESCRIPTION
Added an alternative hosts configuration to README.md for users encountering errors with database.sh pull and push.

Plus some minor typos, and an issue with remote db backups not being removed (deleting 'delegate_to: development_host' from database-backup.yml line 56 fixed it - needs testing).